### PR TITLE
fix: remove blue/slate colors from loading spinners

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -51,8 +51,8 @@ export default function DashboardPage() {
   // Show loading spinner while checking authentication
   if (!isLoaded) {
     return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-primary"></div>
+      <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-zinc-950">
+        <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-gray-300 dark:border-gray-600"></div>
       </div>
     );
   }

--- a/src/app/dashboard/prompt-gallery/page.tsx
+++ b/src/app/dashboard/prompt-gallery/page.tsx
@@ -98,8 +98,8 @@ export default function PromptGalleryPage() {
   // Show loading spinner while checking authentication
   if (!isLoaded) {
     return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-primary"></div>
+      <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-zinc-950">
+        <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-gray-300 dark:border-gray-600"></div>
       </div>
     );
   }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -37,8 +37,8 @@ export default function Home() {
 
   if (!isLoaded) {
     return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-slate-300 dark:border-slate-600"></div>
+      <div className="min-h-screen flex items-center justify-center bg-background">
+        <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-gray-300 dark:border-gray-600"></div>
       </div>
     );
   }


### PR DESCRIPTION
## Problem Fixed

Users were seeing blue/slate colored loading spinners when first loading the website, which didn't match the app's design system.

## Changes Made

- **Landing Page Loading**: Changed from  to 
- **Dashboard Loading**: Changed from  to 
- **Prompt Gallery Loading**: Changed from  to 
- **Added Background Colors**: Ensured consistent background colors during loading states

## Technical Details

- Updated loading spinners in 3 files:
  -  (landing page)
  -  (main dashboard)
  -  (prompt gallery)

## Result

- ✅ No more blue/slate colors during loading
- ✅ Consistent neutral gray colors across all loading states
- ✅ Better user experience with seamless color transitions
- ✅ Loading states now match the app's design system

This fix ensures users see clean, professional loading states that align with the overall design aesthetic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated loading spinner and background colors for improved appearance in both light and dark modes across various loading states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->